### PR TITLE
Update client deletion confirmation

### DIFF
--- a/app/workspace/[id]/clients/components/ClientFormModal.tsx
+++ b/app/workspace/[id]/clients/components/ClientFormModal.tsx
@@ -121,11 +121,9 @@ export default function ClientFormModal({
       };
 
       if (initialData?.id) {
-        console.log(`Modal: Atualizando cliente ${initialData.id}`, clientDataWithMetadata);
         await updateClient(initialData.id, clientDataWithMetadata);
         toast.success('Cliente atualizado com sucesso!');
       } else {
-        console.log("Modal: Criando novo cliente", clientDataWithMetadata);
         await createClient(clientDataWithMetadata);
         toast.success('Cliente criado com sucesso!');
       }

--- a/app/workspace/[id]/clients/components/ClientList.tsx
+++ b/app/workspace/[id]/clients/components/ClientList.tsx
@@ -39,7 +39,7 @@ import type { Client } from '@/app/types';
 
 interface ClientListProps {
   onEdit: (client: Client) => void;
-  onDelete: (clientId: string) => void;
+  onDelete: (clientId: string, skipConfirm?: boolean) => Promise<void>;
   deletingId: string | null;
   loadMoreClients: () => void;
   hasMoreClients: boolean;
@@ -137,7 +137,7 @@ export default function ClientList({
     try {
       toastId = toast.loading('Excluindo clientes selecionados...');
       for (const id of selectedClients) {
-        await onDelete(id);
+        await onDelete(id, true);
       }
       toast.success('Clientes excluídos com sucesso!', { id: toastId });
     } catch (error: any) {
@@ -188,7 +188,6 @@ export default function ClientList({
     setSelectAll(false);
   }, [clients]);
 
-  console.log("ClientList Render: InitialLoading:", initialLoading, "IsLoadingMore:", isLoadingMoreClients, "Error:", clientsError, "Count:", clients?.length ?? 0, "HasMore:", hasMoreClients);
 
   if (clientsError && clients.length === 0) {
     return (

--- a/app/workspace/[id]/clients/page.tsx
+++ b/app/workspace/[id]/clients/page.tsx
@@ -51,10 +51,8 @@ export default function WorkspaceClientsPage() {
         clearClientsError();
     }
     try {
-      console.log(`ClientsPage: Chamando fetchClients para workspace: ${workspace.id}, page: ${page}, search: ${search}, append: ${append}`);
       // A função fetchClients no contexto precisará ser atualizada para lidar com 'append'
       await fetchClients(workspace.id, search, page, CLIENTS_PER_PAGE, append);
-      console.log("ClientsPage: fetchClients concluído.");
     } catch (err) {
       console.error('ClientsPage: Erro ao chamar fetchClients:', err);
       // O erro já deve estar em clientsError ou ser tratado no contexto
@@ -65,7 +63,6 @@ export default function WorkspaceClientsPage() {
   useEffect(() => {
     if (workspace && !workspaceLoading) {
       // Carrega a primeira página quando o termo de busca muda ou o workspace é carregado
-      console.log(`useEffect (search/workspace): Carregando clientes. Search: "${searchTerm}", Page: 1`);
       loadClients(1, searchTerm, false);
     }
   }, [workspace, workspaceLoading, searchTerm, loadClients]); // Não incluir currentPage aqui para evitar loops com o loadMore
@@ -74,7 +71,6 @@ export default function WorkspaceClientsPage() {
   // Função para carregar mais clientes (infinite scroll)
   const loadMoreClients = () => {
     if (!loadingClients && !isLoadingMoreClients && hasMoreClients && workspace) {
-      console.log("ClientsPage: Carregando mais clientes...");
       const nextPage = currentPage + 1;
       setCurrentPage(nextPage); // Atualiza a página atual
       loadClients(nextPage, searchTerm, true); // Chama loadClients para buscar e anexar
@@ -98,16 +94,17 @@ export default function WorkspaceClientsPage() {
   };
 
   // --- Handler de Exclusão (usa contexto) ---
-  const handleDeleteClient = async (clientId: string) => {
+  const handleDeleteClient = async (clientId: string, skipConfirm?: boolean) => {
      if (!workspace) return;
-     if (!confirm('Tem certeza que deseja excluir este cliente? Todas as conversas e mensagens associadas também serão removidas. Esta ação não pode ser desfeita.')) {
-       return;
+     if (!skipConfirm) {
+       if (!confirm('Tem certeza que deseja excluir este cliente? Todas as conversas e mensagens associadas também serão removidas. Esta ação não pode ser desfeita.')) {
+         return;
+       }
      }
      setIsDeleting(clientId);
      setPageError(null); // Limpa erro da página
      clearClientsError(); // Limpa erro do contexto
      try {
-       console.log(`ClientsPage: Chamando deleteClient do contexto para ID: ${clientId}`);
        await deleteClient(clientId, workspace.id); // <<< Chama a função do contexto
        toast.success('Cliente excluído com sucesso.');
        // Recarregar os clientes da página atual após a exclusão, respeitando o searchterm

--- a/app/workspace/[id]/conversations/components/ConversationDetail.tsx
+++ b/app/workspace/[id]/conversations/components/ConversationDetail.tsx
@@ -62,7 +62,6 @@ const getFollowUpStatusDisplay = (status: string | undefined | null): {
 };
 
 export default function ConversationDetail() {
-  console.log('[ConvDetail LIFECYCLE] Rendering/Mounting (Simplified)...');
 
   // --- Context ---
   const {
@@ -125,12 +124,10 @@ export default function ConversationDetail() {
 
   // --- Client Sidebar Handlers ---
   const handleSaveClient = async (clientId: string, updatedData: { name?: string | null; phone_number?: string | null; metadata?: any }) => {
-    console.log(`[ConvDetail] Tentando salvar cliente ${clientId} com dados:`, updatedData);
     try {
         const updatedClientResponse = await updateClient(clientId, updatedData); 
 
         if (conversation) { 
-          console.log("[ConvDetail] Re-selecionando a conversa no contexto com dados do cliente atualizados...");
           const newConversationData: ClientConversation = {
             ...conversation, 
             client: updatedClientResponse 
@@ -138,7 +135,6 @@ export default function ConversationDetail() {
           selectConversation(newConversationData);
         }
 
-        console.log(`[ConvDetail] Cliente ${clientId} salvo (via contexto) e estado da conversa atualizado.`);
     } catch (error: any) {
         console.error(`[ConvDetail] Erro ao salvar cliente ${clientId}:`, error);
         toast.error(`Erro ao salvar cliente: ${error.message || 'Erro desconhecido'}`);
@@ -147,13 +143,11 @@ export default function ConversationDetail() {
   };
 
   const handleDeleteClient = async (clientId: string) => {
-    console.log(`[ConvDetail] Tentando deletar cliente ${clientId}`);
     try {
         if (!conversation?.workspace_id) {
             throw new Error("Workspace ID não encontrado para deletar cliente.");
         }
         await deleteClient(clientId, conversation.workspace_id);
-        console.log(`[ConvDetail] Cliente ${clientId} deletado (via contexto).`);
         selectConversation(null);
     } catch (error: any) {
         console.error(`[ConvDetail] Erro ao deletar cliente ${clientId}:`, error);
@@ -187,7 +181,6 @@ export default function ConversationDetail() {
   // Determinar estado da IA para o botão
   const isAIActive = conversation.is_ai_active;
   const followUpDisplay = getFollowUpStatusDisplay(conversation.activeFollowUp?.status);
-  console.log('[ConvDetail] conversation.activeFollowUp:', conversation.activeFollowUp);
 
   return (
     <div className="flex flex-col h-full bg-card border-l border-border relative">
@@ -266,7 +259,6 @@ export default function ConversationDetail() {
         {isLoadingMessages && messages.length === 0 && <LoadingSpinner message="Carregando..." />}
         {messageError && messages.length === 0 && <ErrorMessage message={messageError} onDismiss={clearMessagesError} />}
         {messages.map((message) => {
-          console.log(`Message ID: ${message.id}, Private Note: ${message.privates_notes}`);
           return (
             <div
               key={message.id}


### PR DESCRIPTION
## Summary
- add optional `skipConfirm` flag when removing a client
- adjust mass deletion calls to avoid repeated confirmation
- expose new parameter in `ClientList` props
- remove leftover console.log statements

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*