### PR TITLE
Atualizar integração de eventos com Pusher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# app_follow-up
+
+Esta aplicação utiliza o Pusher para comunicação em tempo real. Para funcionar, adicione as seguintes variáveis de ambiente ao arquivo `.env.local`:
+
+```
+PUSHER_APP_ID=
+PUSHER_KEY=
+PUSHER_SECRET=
+PUSHER_CLUSTER=
+NEXT_PUBLIC_PUSHER_KEY=
+NEXT_PUBLIC_PUSHER_CLUSTER=
+```
+
+Instale as dependências e execute os workers e o servidor:
+
+```bash
+pnpm install
+pnpm dev
+```

--- a/lib/actions/conversationActions.ts
+++ b/lib/actions/conversationActions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { prisma } from '@/lib/db';
-import { redisConnection } from '@/lib/redis';
+import pusher from '@/lib/pusher';
 
 /**
  * Define o estado da IA para uma conversa específica e publica um evento no Redis.
@@ -43,8 +43,8 @@ export async function setConversationAIStatus(conversationId: string, newStatus:
 
       try {
            await Promise.all([
-             redisConnection.publish(chatChannel, JSON.stringify(eventPayload)),
-             redisConnection.publish(workspaceChannel, JSON.stringify(eventPayload)),
+             pusher.trigger(chatChannel, 'ai_status_updated', eventPayload),
+             pusher.trigger(workspaceChannel, 'ai_status_updated', eventPayload),
            ]);
            console.log(`[Action] Evento 'ai_status_updated' (status: ${newStatus}) publicado nos canais ${chatChannel} e ${workspaceChannel}`);
            return true; // Sucesso na operação completa (DB + Redis)

--- a/lib/services/notifierService.ts
+++ b/lib/services/notifierService.ts
@@ -1,4 +1,4 @@
-import { redisConnection } from '@/lib/redis';
+import pusher from '@/lib/pusher';
 
 /**
  * Publica atualização de nova mensagem no canal da conversa.
@@ -7,8 +7,7 @@ export async function publishConversationUpdate(
   channel: string,
   payload: any
 ): Promise<void> {
-  // Publica o payload no canal especificado
-  await redisConnection.publish(channel, JSON.stringify(payload));
+  await pusher.trigger(channel, 'update', payload);
 }
 
 /**
@@ -18,6 +17,5 @@ export async function publishWorkspaceUpdate(
   channel: string,
   payload: any
 ): Promise<void> {
-  // Publica o payload no canal especificado
-  await redisConnection.publish(channel, JSON.stringify(payload));
+  await pusher.trigger(channel, 'update', payload);
 }


### PR DESCRIPTION
## Resumo
- configurar Pusher no serviço de notificações
- usar o Pusher ao atualizar status da IA
- ajustar rota de envio de templates
- publicar progresso de campanhas via Pusher
- documentar variáveis de ambiente no README

## Testes
- `pnpm lint` *(falhou: EHOSTUNREACH ao baixar dependências)*