### PR TITLE
Migrar eventos em tempo real para Pusher

### DIFF
--- a/lib/services/notifierService.ts
+++ b/lib/services/notifierService.ts
@@ -1,4 +1,4 @@
-import { redisConnection } from '@/lib/redis';
+import pusher from '@/lib/pusher';
 
 /**
  * Publica atualização de nova mensagem no canal da conversa.
@@ -7,8 +7,7 @@ export async function publishConversationUpdate(
   channel: string,
   payload: any
 ): Promise<void> {
-  // Publica o payload no canal especificado
-  await redisConnection.publish(channel, JSON.stringify(payload));
+  await pusher.trigger(channel, payload.type, JSON.stringify(payload));
 }
 
 /**
@@ -18,6 +17,5 @@ export async function publishWorkspaceUpdate(
   channel: string,
   payload: any
 ): Promise<void> {
-  // Publica o payload no canal especificado
-  await redisConnection.publish(channel, JSON.stringify(payload));
+  await pusher.trigger(channel, payload.type, JSON.stringify(payload));
 }


### PR DESCRIPTION
## Summary
- enviar atualizações de IA via Pusher
- publicar mensagens e status usando Pusher
- remover publicações Redis de rotas e workers
- adaptar serviço de notificações para usar Pusher

## Testing
- `pnpm lint` *(falhou: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.10.0.tgz)*