### PR TITLE
Corrige reativação involuntária da IA

### DIFF
--- a/lib/services/createConversation.ts
+++ b/lib/services/createConversation.ts
@@ -92,7 +92,7 @@ export async function getOrCreateConversation(
             data: {
                 last_message_at: new Date(),
                 status: ConversationStatus.ACTIVE, // Reativa se estava fechada
-                is_ai_active: true, // Garante que IA está ativa ao reabrir/continuar
+                // Mantém valor atual de is_ai_active, não o sobrescreve
             }
         });
         // conversationWasCreated permanece false, pois a conversa já existia


### PR DESCRIPTION
## Mudança
- remove a atualização automática do campo `is_ai_active` ao reabrir conversas existentes em `getOrCreateConversation`

## Testes
- `pnpm lint` *(falhou: falta de acesso à rede)*