### PR TITLE
Implementa busca e contadores globais nas conversas

### DIFF
--- a/app/workspace/[id]/conversations/components/ConversationDetail.tsx
+++ b/app/workspace/[id]/conversations/components/ConversationDetail.tsx
@@ -68,12 +68,15 @@ export default function ConversationDetail() {
     selectedConversation: conversation,
     selectedConversationMessages: messages,
     loadingSelectedConversationMessages: isLoadingMessages,
+    isLoadingMoreMessages,
+    hasMoreMessages,
     selectedConversationError: messageError,
     isSendingMessage,
     clearMessagesError,
     selectConversation,
     sendMediaMessage,
     sendTemplateMessage,
+    loadMoreMessages,
     toggleAIStatus,
     isTogglingAIStatus,
   } = useConversationContext();
@@ -256,6 +259,13 @@ export default function ConversationDetail() {
 
       {/* Messages */}
       <ScrollArea ref={scrollAreaRef} className="flex-grow p-4 overflow-y-auto">
+        {hasMoreMessages && (
+          <div className="flex justify-center mb-2">
+            <Button variant="ghost" size="sm" onClick={loadMoreMessages} disabled={isLoadingMoreMessages}>
+              {isLoadingMoreMessages ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Carregar mais'}
+            </Button>
+          </div>
+        )}
         {isLoadingMessages && messages.length === 0 && <LoadingSpinner message="Carregando..." />}
         {messageError && messages.length === 0 && <ErrorMessage message={messageError} onDismiss={clearMessagesError} />}
         {messages.map((message) => {

--- a/app/workspace/[id]/conversations/components/ConversationList.tsx
+++ b/app/workspace/[id]/conversations/components/ConversationList.tsx
@@ -5,17 +5,21 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import type { ClientConversation } from '@/app/types';
 import { cn } from '@/lib/utils';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useConversationContext } from '@/context/ConversationContext';
 import { User } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRouter, usePathname } from 'next/navigation';
+import LoadingSpinner from '@/components/ui/LoadingSpinner';
 
 interface ConversationListProps {
   conversations: ClientConversation[];
   selectedConversationId: string | null;
   onSelectConversation: (conversation: ClientConversation) => void;
   basePath: string;
+  loadMoreConversations: () => void;
+  hasMoreConversations: boolean;
+  isLoadingMoreConversations: boolean;
 }
 
 export default function ConversationList({
@@ -23,9 +27,24 @@ export default function ConversationList({
   selectedConversationId,
   onSelectConversation,
   basePath,
+  loadMoreConversations,
+  hasMoreConversations,
+  isLoadingMoreConversations,
 }: ConversationListProps) {
   const { unreadConversationIds } = useConversationContext(); // Get unread IDs
   const router = useRouter();
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const lastElementRef = useCallback((node: HTMLButtonElement | null) => {
+    if (isLoadingMoreConversations) return;
+    if (observer.current) observer.current.disconnect();
+    observer.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasMoreConversations) {
+        loadMoreConversations();
+      }
+    });
+    if (node) observer.current.observe(node);
+  }, [isLoadingMoreConversations, hasMoreConversations, loadMoreConversations]);
 
   useEffect(() => {
     console.log('[ConversationList] Unread IDs atualizado:', unreadConversationIds);
@@ -46,7 +65,7 @@ export default function ConversationList({
 
   return (
     <div className="overflow-y-auto h-full">
-      {conversations.map((convo) => {
+      {conversations.map((convo, index) => {
         console.log('[ConversationList] Mapping convo ID:', convo?.id, 'Convo:', convo);
         if (!convo || !convo.id) {
           console.error('[ConversationList] Found conversation with missing ID:', convo);
@@ -65,6 +84,7 @@ export default function ConversationList({
 
         return (
           <button
+            ref={conversations.length === index + 1 ? lastElementRef : null}
             key={convo.id}
             onClick={() => {
               onSelectConversation(convo);
@@ -131,6 +151,16 @@ export default function ConversationList({
           </button>
         );
       })}
+      {isLoadingMoreConversations && (
+        <div className="flex justify-center items-center py-4">
+          <LoadingSpinner message="Carregando mais conversas..." />
+        </div>
+      )}
+      {!isLoadingMoreConversations && !hasMoreConversations && conversations.length > 0 && (
+        <div className="text-center text-muted-foreground py-4 text-sm">
+          Fim da lista de conversas.
+        </div>
+      )}
     </div>
   );
 }

--- a/context/ConversationContext.tsx
+++ b/context/ConversationContext.tsx
@@ -58,10 +58,14 @@ interface ConversationContextType {
     // Estados
     conversations: ClientConversation[];
     loadingConversations: boolean;
+    isLoadingMoreConversations: boolean;
+    hasMoreConversations: boolean;
     conversationsError: string | null;
     selectedConversation: ClientConversation | null;
     selectedConversationMessages: Message[];
     loadingSelectedConversationMessages: boolean;
+    isLoadingMoreMessages: boolean;
+    hasMoreMessages: boolean;
     selectedConversationError: string | null;
     messageCache: Record<string, Message[]>;
     unreadConversationIds: Set<string>;
@@ -70,10 +74,13 @@ interface ConversationContextType {
     isTogglingAIStatus: boolean;
     isPusherConnected: boolean;
     loadingPusherConfig: boolean;
+    aiCounts: { all: number; human: number; ai: number };
 
     // Funções de Busca/Seleção
-    fetchConversations: (filter?: string, workspaceId?: string) => Promise<void>;
-    fetchConversationMessages: (conversationId: string) => Promise<Message[]>;
+    fetchConversations: (filter: string, workspaceId: string, page: number, pageSize: number, append?: boolean, search?: string) => Promise<void>;
+    fetchConversationMessages: (conversationId: string, page: number, pageSize: number, append?: boolean) => Promise<Message[]>;
+    loadMoreConversations: () => void;
+    loadMoreMessages: () => void;
     selectConversation: (conversation: ClientConversation | null) => void;
     clearMessagesError: () => void;
 
@@ -113,6 +120,15 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
     const [unreadConversationIds, setUnreadConversationIds] = useState<Set<string>>(new Set());
     const [isSendingMessage, setIsSendingMessage] = useState(false);
     const [isTogglingAIStatus, setIsTogglingAIStatus] = useState(false);
+    const [isLoadingMoreConversations, setIsLoadingMoreConversations] = useState(false);
+    const [hasMoreConversations, setHasMoreConversations] = useState(true);
+    const [isLoadingMoreMessages, setIsLoadingMoreMessages] = useState(false);
+    const [hasMoreMessages, setHasMoreMessages] = useState(true);
+    const [currentConversationsPage, setCurrentConversationsPage] = useState(1);
+    const [currentMessagesPage, setCurrentMessagesPage] = useState(1);
+    const [currentFilter, setCurrentFilter] = useState('ATIVAS');
+    const [currentSearch, setCurrentSearch] = useState('');
+    const [aiCounts, setAiCounts] = useState({ all: 0, human: 0, ai: 0 });
 
 
     // --- Efeito para Carregar Estado Inicial de Não Lidos do Local Storage --- //
@@ -159,29 +175,55 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
 
 
     // --- Funções de Busca/Seleção --- //
-    const fetchConversationMessages = useCallback(async (conversationId: string): Promise<Message[]> => {
-        if (messageCache[conversationId]) {
+    const fetchConversationMessages = useCallback(async (
+        conversationId: string,
+        page: number = 1,
+        pageSize: number = 20,
+        append: boolean = false,
+    ): Promise<Message[]> => {
+        if (!append && messageCache[conversationId]) {
             setSelectedConversationMessages(messageCache[conversationId]);
             setLoadingSelectedConversationMessages(false);
             return messageCache[conversationId];
         }
-        setLoadingSelectedConversationMessages(true);
+        if (append) {
+            setIsLoadingMoreMessages(true);
+        } else {
+            setLoadingSelectedConversationMessages(true);
+            setCurrentMessagesPage(page);
+            setHasMoreMessages(true);
+        }
         setSelectedConversationError(null);
         try {
-            const fetchedMessages = await fetchConversationMessagesApi(conversationId);
-            setMessageCache(prev => ({ ...prev, [conversationId]: fetchedMessages }));
-            setSelectedConversationMessages(fetchedMessages);
+            const { data: fetchedMessages, hasMore } = await fetchConversationMessagesApi(conversationId, (page - 1) * pageSize, pageSize);
+            if (append) {
+                setMessageCache(prev => ({ ...prev, [conversationId]: [...(prev[conversationId] || []), ...fetchedMessages] }));
+                setSelectedConversationMessages(prev => [...prev, ...fetchedMessages]);
+            } else {
+                setMessageCache(prev => ({ ...prev, [conversationId]: fetchedMessages }));
+                setSelectedConversationMessages(fetchedMessages);
+            }
+            setHasMoreMessages(hasMore);
             return fetchedMessages;
         } catch (err: any) {
             const message = err.message || 'Erro ao buscar mensagens.';
             setSelectedConversationError(message);
-            setSelectedConversationMessages([]);
+            if (!append) setSelectedConversationMessages([]);
             toast.error(`Erro ao buscar mensagens: ${message}`);
+            setHasMoreMessages(false);
             return [];
         } finally {
             setLoadingSelectedConversationMessages(false);
+            setIsLoadingMoreMessages(false);
         }
     }, [messageCache, setMessageCache, setSelectedConversationMessages, setLoadingSelectedConversationMessages, setSelectedConversationError]);
+
+    const loadMoreMessages = useCallback(() => {
+        if (isLoadingMoreMessages || !hasMoreMessages || !selectedConversation) return;
+        const nextPage = currentMessagesPage + 1;
+        fetchConversationMessages(selectedConversation.id, nextPage, 20, true);
+        setCurrentMessagesPage(nextPage);
+    }, [isLoadingMoreMessages, hasMoreMessages, selectedConversation, currentMessagesPage, fetchConversationMessages]);
 
     const selectConversation = useCallback((conversation: ClientConversation | null) => {
         const newConversationId = conversation?.id ?? null;
@@ -195,7 +237,7 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
         setLoadingSelectedConversationMessages(false);
 
         if (conversation) {
-            fetchConversationMessages(conversation.id);
+            fetchConversationMessages(conversation.id, 1, 20, false);
             setUnreadConversationIds(prev => {
                 if (prev.has(conversation.id)) {
                     const newSet = new Set(prev);
@@ -207,7 +249,14 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
         } 
     }, [selectedConversation, setUnreadConversationIds, messageCache, fetchConversationMessages]);
 
-     const fetchConversations = useCallback(async (filter = 'ATIVAS', workspaceId?: string) => {
+     const fetchConversations = useCallback(async (
+        filter: string = 'ATIVAS',
+        workspaceId?: string,
+        page: number = 1,
+        pageSize: number = 20,
+        append: boolean = false,
+        search: string = '',
+     ) => {
         const wsId = getActiveWorkspaceId(workspaceContext, workspaceId);
         if (!wsId) {
             setConversationsError("Workspace ID não encontrado.");
@@ -215,11 +264,25 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
             selectConversation(null);
             return;
         }
-        setLoadingConversations(true);
+        if (append) {
+            setIsLoadingMoreConversations(true);
+        } else {
+            setLoadingConversations(true);
+            setCurrentConversationsPage(page);
+            setHasMoreConversations(true);
+            setCurrentFilter(filter);
+            setCurrentSearch(search);
+        }
         setConversationsError(null);
         try {
-            const fetchedData = await fetchConversationsApi(filter, wsId);
-            setConversations(fetchedData);
+            const { data: fetchedData, hasMore, counts } = await fetchConversationsApi(filter, wsId, page, pageSize, search);
+            if (append) {
+                setConversations(prev => [...prev, ...fetchedData]);
+            } else {
+                setConversations(fetchedData);
+            }
+            setHasMoreConversations(hasMore);
+            setAiCounts(counts);
             // console.log(`[ConversationContext] Fetched ${fetchedData.length} conversations with filter ${filter}.`); // DEBUG
 
             // Lógica de auto-seleção
@@ -249,8 +312,16 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
             toast.error(message);
         } finally {
             setLoadingConversations(false);
+            setIsLoadingMoreConversations(false);
         }
     }, [workspaceContext.workspace?.id, selectedConversation?.id, selectConversation]);
+
+    const loadMoreConversations = useCallback(() => {
+        if (isLoadingMoreConversations || !hasMoreConversations) return;
+        const nextPage = currentConversationsPage + 1;
+        fetchConversations(currentFilter, undefined, nextPage, 20, true, currentSearch);
+        setCurrentConversationsPage(nextPage);
+    }, [isLoadingMoreConversations, hasMoreConversations, currentConversationsPage, fetchConversations, currentFilter]);
 
     const clearMessagesError = useCallback(() => {
         setSelectedConversationError(null);
@@ -900,10 +971,14 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
     const contextValue = useMemo(() => ({
         conversations,
         loadingConversations,
+        isLoadingMoreConversations,
+        hasMoreConversations,
         conversationsError,
         selectedConversation,
         selectedConversationMessages,
         loadingSelectedConversationMessages,
+        isLoadingMoreMessages,
+        hasMoreMessages,
         selectedConversationError,
         messageCache,
         unreadConversationIds,
@@ -912,8 +987,11 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
         isTogglingAIStatus,
         isPusherConnected,
         loadingPusherConfig,
+        aiCounts,
         fetchConversations,
         fetchConversationMessages,
+        loadMoreConversations,
+        loadMoreMessages,
         selectConversation,
         clearMessagesError,
         handleRealtimeNewMessage,
@@ -925,12 +1003,13 @@ export const ConversationProvider: React.FC<{ children: ReactNode }> = ({ childr
         sendMediaMessage,
         toggleAIStatus,
     }), [
-        conversations, loadingConversations, conversationsError, selectedConversation,
-        selectedConversationMessages, loadingSelectedConversationMessages, selectedConversationError,
+        conversations, loadingConversations, isLoadingMoreConversations, hasMoreConversations, conversationsError,
+        selectedConversation,
+        selectedConversationMessages, loadingSelectedConversationMessages, isLoadingMoreMessages, hasMoreMessages, selectedConversationError,
         messageCache, unreadConversationIds, isSendingMessage, isTogglingAIStatus,
-        isPusherConnected, loadingPusherConfig,
-        fetchConversations, fetchConversationMessages, selectConversation, clearMessagesError,
-        handleRealtimeNewMessage, handleRealtimeStatusUpdate, handleRealtimeAIStatusUpdate, 
+        isPusherConnected, loadingPusherConfig, aiCounts,
+        fetchConversations, fetchConversationMessages, loadMoreConversations, loadMoreMessages, selectConversation, clearMessagesError,
+        handleRealtimeNewMessage, handleRealtimeStatusUpdate, handleRealtimeAIStatusUpdate,
         selectConversationForClient,
         sendManualMessage,
         sendTemplateMessage, sendMediaMessage, toggleAIStatus,

--- a/lib/services/conversationApi.ts
+++ b/lib/services/conversationApi.ts
@@ -1,22 +1,39 @@
 import axios from 'axios';
 import type { ClientConversation, Message } from '@/app/types';
 
-export async function fetchConversationsApi(filter: string, workspaceId: string): Promise<ClientConversation[]> {
-  const response = await axios.get<{ success: boolean; data?: ClientConversation[]; error?: string }>('/api/conversations', {
-    params: { workspaceId, status: filter },
+export async function fetchConversationsApi(
+  filter: string,
+  workspaceId: string,
+  page: number,
+  pageSize: number,
+  search: string,
+): Promise<{ data: ClientConversation[]; hasMore: boolean; counts: { all: number; human: number; ai: number } }> {
+  const response = await axios.get<{ success: boolean; data?: ClientConversation[]; error?: string; hasMore?: boolean; counts?: { all: number; human: number; ai: number } }>('/api/conversations', {
+    params: { workspaceId, status: filter, page, pageSize, search },
   });
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Falha ao carregar conversas');
   }
-  return response.data.data;
+  return {
+    data: response.data.data,
+    hasMore: Boolean(response.data.hasMore),
+    counts: response.data.counts || { all: 0, human: 0, ai: 0 },
+  };
 }
 
-export async function fetchConversationMessagesApi(conversationId: string): Promise<Message[]> {
-  const response = await axios.get<{ success: boolean; data?: Message[]; error?: string }>(
-    `/api/conversations/${conversationId}/messages`
+export async function fetchConversationMessagesApi(
+  conversationId: string,
+  offset: number,
+  limit: number,
+): Promise<{ data: Message[]; hasMore: boolean }> {
+  const response = await axios.get<{ success: boolean; data?: Message[]; error?: string; hasMore?: boolean }>(
+    `/api/conversations/${conversationId}/messages`,
+    { params: { offset, limit } },
   );
   if (!response.data.success || !response.data.data) {
     throw new Error(response.data.error || 'Falha ao carregar mensagens');
   }
-  return response.data.data.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+  const sorted = response.data.data.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+  return { data: sorted, hasMore: Boolean(response.data.hasMore) };
 }
+


### PR DESCRIPTION
## Notas
- Ajusta API de conversas para aceitar `search` e retornar contagem total de conversas por tipo de atendimento (IA/Humano).
- Atualiza serviço e contexto para repassar `search` e salvar os totais.
- Adiciona campo de busca na página de conversas e exibe contadores vindos da API.

## Testes
- `pnpm lint` falhou por não conseguir baixar dependências.