### PR TITLE
Adicionar hook useDebounce e substituir timeout

### DIFF
--- a/app/workspace/[id]/conversations/[[...conversationId]]/page.tsx
+++ b/app/workspace/[id]/conversations/[[...conversationId]]/page.tsx
@@ -2,6 +2,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import useDebounce from '@/hooks/useDebounce';
 import { useParams, useRouter, usePathname } from 'next/navigation';
 import { useWorkspace } from '@/context/workspace-context';
 import { useConversationContext } from '@/context/ConversationContext';
@@ -41,16 +42,11 @@ export default function ConversationsPage() {
   const [aiFilter, setAiFilter] = useState<AiFilterType>('all');
   const [currentPage, setCurrentPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState('');
-  const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 300);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(event.target.value);
   };
-
-  useEffect(() => {
-    const handler = setTimeout(() => setDebouncedSearchTerm(searchTerm), 300);
-    return () => clearTimeout(handler);
-  }, [searchTerm]);
 
   const urlConversationId = Array.isArray(params.conversationId) && params.conversationId.length > 0
     ? params.conversationId[0]

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebounce;


### PR DESCRIPTION
## Resumo
- criar `hooks/useDebounce.ts` para disponibilizar valor com atraso configurável
- aplicar o novo hook em `ConversationsPage` removendo o `setTimeout` manual

## Testes
- `pnpm lint` *(falhou: sem acesso à rede)*
- `pnpm test` *(falhou: sem acesso à rede)*